### PR TITLE
Add kernel definition for MARK debian-sources

### DIFF
--- a/contrib/kernel-profiles/debian.yml
+++ b/contrib/kernel-profiles/debian.yml
@@ -1,0 +1,5 @@
+name: "MARK debian-sources"
+kernel_prefix: "vmlinuz"
+suffix: "mark"
+type: "debian"
+with_arch: true


### PR DESCRIPTION
This PR adds a kernel profile definition for the kernel/modules/initramfs produced by the `debian-sources` ebuild.